### PR TITLE
メッセージ投稿機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,7 @@ gem 'font-awesome-sass'
 gem 'devise'
 
 gem 'pry-rails'
+
+gem 'carrierwave'
+
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,11 +38,20 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (7.1.4)
     bcrypt (3.1.13)
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.1)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -82,6 +91,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    image_processing (1.10.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jquery-rails (4.3.5)
@@ -97,6 +109,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mimemagic (0.3.4)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -110,6 +124,7 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.3)
     puma (3.12.4)
     rack (2.2.2)
     rack-test (0.6.3)
@@ -144,6 +159,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
     sass (3.7.4)
@@ -198,6 +215,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   font-awesome-sass
@@ -205,6 +223,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   pry-rails
   puma (~> 3.0)

--- a/app/assets/stylesheets/modules/_main_chat.scss
+++ b/app/assets/stylesheets/modules/_main_chat.scss
@@ -42,6 +42,7 @@
     background-color: $contents-box;
     height: calc(100vh - 190px);
     padding: 35px 40px;
+    overflow: scroll;
     .comments-box {
       margin-bottom: 46px;
       &__users {
@@ -72,7 +73,6 @@
       display: flex;
       .write-box {
         width: 100%;
-        display: flex;
         position: relative;
         &__text {
           height: 50px;
@@ -83,7 +83,7 @@
           cursor: pointer;
           position: absolute;
           right: 10px;
-          line-height: 50px;
+          top: 7px;
           font-size: 25px;
           &__file {
             display: none;

--- a/app/assets/stylesheets/modules/_user.scss
+++ b/app/assets/stylesheets/modules/_user.scss
@@ -98,8 +98,8 @@
   }
 
   .field-input {
-    .field_with_errors {
-      position: relative;
+    // .field_with_errors {
+    //   position: relative;
 
       &:after {
         content: '';
@@ -113,7 +113,7 @@
       }
     }
   }
-}
+// }
 
 #error_explanation {
   margin: 20px 0;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -24,7 +24,7 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: 'グループを更新しました'
+      redirect_to group_messages_path(@group), notice: 'グループを更新しました'
     else
       render :edit
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,29 @@
 class MessagesController < ApplicationController
+  before_action :set_group
+
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
+  end
+
+  def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,20 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
+
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      if last_message.content?
+        last_message.content
+      else
+        '画像が投稿されています'
+      end
+    else
+      'まだメッセージはありません。'
+    end
+  end
+
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,8 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+
+  mount_uploader :image, ImageUploader
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   has_many :group_users
   has_many :groups, through: :group_users
+  has_many :messages
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,49 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  process resize_to_fit: [800, 800]
+  
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -3,29 +3,25 @@
   .main-chat__header
     .group-list
       %h2.group-list__name
-        test
+        = @group.name
       %ul.group-list__members
         Member : 
-        %li.group-list__members--names
-          test
+        - @group.users.each do |user|
+          %li.group-list__members--names
+            = user.name
+
     .edit-group
-      = link_to "#" do
+      = link_to edit_group_path(@group) do
         Edit
 
   .main-chat__contents
-    .comments-box
-      .comments-box__users
-        .comments-box__users--name
-          test
-        .comments-box__users--time
-          2020/03/06(Fri) 17:00:00
-      .comments-box__text
-        テストです
+    = render @messages
   .main-chat__form
-    %from.input-box
-      .write-box
-        %input{type: "text", placeholder: "type a message", class: "write-box__text"}
-        %label{class: "write-box__image"}
-          = icon('far', 'image')
-          %input{type: "file", class: "write-box__image__file"}
-      %input{type: "submit", value: "Send", class: "send-btn"}
+    = form_for [@group, @message] do |f|
+      .input-box
+        .write-box
+          = f.text_field :content, class: 'write-box__text', placeholder: 'type a message'
+          = f.label :image, class: 'write-box__image' do
+            = icon('far', 'image')
+            = f.file_field :image, class: 'write-box__image__file'
+        = f.submit 'Send', class: 'send-btn'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,12 @@
+.comments-box
+  .comments-box__users
+    .comments-box__users--name
+      = message.user.name
+    .comments-box__users--time
+      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  .comments-box__text
+    - if message.content.present?
+      %p.comments-box__text__content
+        = message.content
+    = image_tag message.image.url, class: 'comments-box__text__image' if message.image.present?
+

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -14,8 +14,8 @@
   .side-bar__groups
     - current_user.groups.each do |group|
       .groups-box
-        = link_to '#' do
+        = link_to group_messages_path(group) do
           .groups-box__name
             = group.name
           .groups-box__message
-            まだメッセージはありません
+            = group.show_last_message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end

--- a/db/migrate/20200309063010_create_messages.rb
+++ b/db/migrate/20200309063010_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200309030209) do
+ActiveRecord::Schema.define(version: 20200309063010) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 20200309030209) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -44,4 +55,6 @@ ActiveRecord::Schema.define(version: 20200309030209) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# What
メッセージの投稿機能を実装。
サイドバーのグループ名の下に最新のメッセージを表示。
投稿されたメッセージの上のブロックにグループ名とメンバーを表示。
Editを押すとグループ編集画面に飛ぶように実装。
# Why
投稿されたメッセージを保存、表示させるのに必要不可欠なため。